### PR TITLE
fix(signuppage): double check email exists validation and alert dialo…

### DIFF
--- a/lib/pages/auth/signup.dart
+++ b/lib/pages/auth/signup.dart
@@ -106,7 +106,7 @@ class _SignUpPageState extends State<SignUpPage> {
         context: context,
         builder: (BuildContext context) {
           return AlertDialog(
-            title: Text('An Error Occurred!'),
+            title: Text('Aw Geeze!'),
             content: Text(successInformation['message']),
             actions: <Widget>[
               FlatButton(

--- a/lib/scoped-models/connected_user_alarm.dart
+++ b/lib/scoped-models/connected_user_alarm.dart
@@ -95,7 +95,7 @@ mixin UserModel on ConnectedUserAlarmModel {
       message = 'The password is invalid.';
     }
 
-    print('USER: ${_authenticatedUser.email}');
+    // print('USER: ${_authenticatedUser.email}');
     _isLoading = false;
     notifyListeners();
     return {'success': !hasError, 'message': message};


### PR DESCRIPTION
re #13

the code was actually there already. I tested and you should be seeing an alert box show up if firebase sends back an error, as long as you pass the front end validations. 

Let me know if you still see a never ending loading spinner. I can't seem to recreate that